### PR TITLE
ci: fix validation and use Read the Docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
-name: CI
+name: Manual validation
 
-on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+on: workflow_dispatch
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
   python:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest
-    if: hashFiles('pysdk/pyproject.toml') != ''
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,4 +1,4 @@
-# DLC conformance gate — the M31-M37 compliance program's CI lane.
+# DLC conformance gate for explicit, manually requested remote runs.
 #
 # Runs the full gate sequence from scripts/ci-gates.sh:
 #   stubs → go → cpp → lockfile → static → sweep → ivct
@@ -8,8 +8,7 @@
 # in both directions (regression AND unrecorded improvement fail).
 #
 # The Pitch parity lane (capturing goldens from a live pRTI) remains
-# local-only, gated on PRTI_HOME — Pitch cannot be redistributed to CI.
-# CI verifies gorti against the *committed* goldens.
+# local-only, gated on PRTI_HOME because Pitch cannot be redistributed.
 #
 # First run builds gRPC/protobuf via conan (~40-60 min); later runs hit
 # the conan cache (~10-15 min total).
@@ -17,10 +16,6 @@
 name: Conformance
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: GitHub Pages readiness
 
 on:
   pull_request:
@@ -45,3 +45,11 @@ jobs:
 
       - name: Build documentation
         run: mkdocs build --strict
+
+      - name: Verify site entry point
+        run: test -s site/index.html
+
+      - name: Package Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,21 +1,10 @@
-name: Deploy docs to GitHub Pages
-
-# Builds the MkDocs Material site at docs/ and publishes it to
-# https://cbchoi.github.io/gorti/. Runs on every push to main; the
-# workflow_dispatch trigger lets you redeploy manually from the
-# Actions tab.
-#
-# Setup (one-time, in the repo Settings UI):
-#   Settings → Pages → Source = "GitHub Actions"
-#
-# After that, every push to main republishes the site.
+name: Docs
 
 on:
   pull_request:
     branches: [main]
     paths:
       - "docs/**"
-      - "paper/**"
       - "mkdocs.yml"
       - ".readthedocs.yaml"
       - "CITATION.cff"
@@ -25,7 +14,6 @@ on:
     branches: [main]
     paths:
       - "docs/**"
-      - "paper/**"
       - "mkdocs.yml"
       - ".readthedocs.yaml"
       - "CITATION.cff"
@@ -36,18 +24,10 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment; cancel runs queued after a
-# more recent push but let an in-flight deployment finish so a
-# half-deployed site isn't visible.
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   build:
+    name: MkDocs strict build
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -60,28 +40,8 @@ jobs:
           cache: pip
           cache-dependency-path: docs/requirements.txt
 
-      - name: Install MkDocs + plugins
+      - name: Install documentation dependencies
         run: pip install -r docs/requirements.txt
 
-      - name: Build site
+      - name: Build documentation
         run: mkdocs build --strict
-
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    if: github.event_name != 'pull_request'
-    needs: build
-    runs-on: ubuntu-22.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,22 @@ python -m pip install -r docs/requirements.txt
 python -m mkdocs build --strict
 ```
 
+GitHub Actions automatically checks only whether the documentation can be
+built and packaged as a GitHub Pages artifact. Run code and conformance checks
+locally before opening a pull request:
+
+```bash
+buf generate
+go test ./...
+ruff check pysdk
+cd pysdk && mypy --strict . && pytest --maxfail=1
+cd ..
+bash scripts/ci-gates.sh
+```
+
+The complete conformance gate requires the C++ toolchain and Conan described in
+the SDK documentation. On Windows, run the shell gate from WSL or Git Bash.
+
 ## Pull requests
 
 - Add focused tests for behavioral changes.

--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ IEEE 1516-2010 (HLA Evolved) only — not 1516-2000, not 1.3, not HLA 4.
 ## Documentation and citation
 
 The user documentation builds strictly from `.readthedocs.yaml` and
-`mkdocs.yml`. Public Read the Docs and GitHub Pages hosting are release setup
-gates. Start with the [installation guide](docs/installation.md),
+`mkdocs.yml`. Public Read the Docs hosting must be enabled separately. Start
+with the [installation guide](docs/installation.md),
 [two-federate quickstart](docs/quickstart.md), and
 [reproducibility protocol](docs/reproducibility.md).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Open-source [IEEE 1516-2010 (HLA Evolved)](https://standards.ieee.org/ieee/1516/4118/) Run-Time Infrastructure in Go, with a spec-strict IEEE 1516.1-2010 DLC C++ federate SDK, a Python federate SDK, and a [pyjevsim](https://github.com/cbchoi/pyjevsim) DEVS bridge.
 
 **Development status (v0.9.0 development version; latest public release
-v0.1.0)**: full HLA Evolved service surface with a CI-enforced
+v0.1.0)**: full HLA Evolved service surface with a locally verified
 conformance program — 27/27 conformance fixtures at FULL/SPEC-FULL
 (canonicalized event sequences byte-identical to their goldens; the 3
 goldens capturable under Pitch pRTI Free's 2-federate cap were captured
@@ -39,8 +39,8 @@ What's in the box:
 - **Cross-language byte-identical encoding** — Python, Go, and C++ agree on
   every entry of `tests/conformance/encoding_vectors.json`; proven live by
   the `xlang_python_cpp_pubsub` fixture (Python publisher → C++ subscriber).
-- **Conformance CI** — `scripts/ci-gates.sh` re-runs every fixture against
-  a fresh RTI on each commit and fails on any verdict change in either
+- **Local conformance gate** — `scripts/ci-gates.sh` re-runs every fixture
+  against a fresh RTI and fails on any verdict change in either
   direction (see `cppsdk/tests/dlc/conformance/EXPECTED_VERDICTS.txt`),
   plus an IVCT-inspired Python subset (35 tests, 0 xfail).
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -135,8 +135,8 @@ automatically. Python 3.11+.
 
 ## 5. Verification checklist (per release)
 
-CI already gates correctness on every push/PR (`.github/workflows/conformance.yml`
-+ `ci.yml`). At tag time, additionally confirm:
+Run the code and conformance gates locally with `make test` and
+`scripts/ci-gates.sh`. At tag time, additionally confirm:
 
 - [ ] `pysdk/pyproject.toml` version == tag (the PyPI workflow enforces this)
 - [ ] GitHub Release contains 6 archives (linux/darwin/windows × amd64/arm64 ×

--- a/docs/readthedocs.md
+++ b/docs/readthedocs.md
@@ -1,8 +1,8 @@
 # Publishing documentation
 
-The repository is configured for Read the Docs and GitHub Pages. The local and
-CI builds are strict and use the same pinned dependencies. The public hosting
-projects must still be enabled in their respective service settings.
+The repository is configured for Read the Docs. Local and CI builds are strict
+and use the same pinned dependencies. The public hosting project must still be
+enabled in the Read the Docs service settings.
 
 ## Local build
 
@@ -23,9 +23,6 @@ python -m mkdocs build --strict
 `.readthedocs.yaml` selects Ubuntu 22.04, Python 3.11, `mkdocs.yml`, and the
 pinned requirements in `docs/requirements.txt`.
 
-## GitHub Pages
-
-The documentation workflow runs `mkdocs build --strict` on pull requests and
-pushes. Deployment runs only for `main` after GitHub Pages is configured to use
-GitHub Actions. Keep links relative so the same content renders correctly on
-both hosts.
+The `Docs` GitHub Actions workflow validates the same strict build on pull
+requests and pushes. Read the Docs owns publication; GitHub Actions does not
+deploy a second copy of the site.

--- a/docs/readthedocs.md
+++ b/docs/readthedocs.md
@@ -23,6 +23,7 @@ python -m mkdocs build --strict
 `.readthedocs.yaml` selects Ubuntu 22.04, Python 3.11, `mkdocs.yml`, and the
 pinned requirements in `docs/requirements.txt`.
 
-The `Docs` GitHub Actions workflow validates the same strict build on pull
-requests and pushes. Read the Docs owns publication; GitHub Actions does not
-deploy a second copy of the site.
+The `GitHub Pages readiness` Actions workflow validates the same strict build,
+checks the generated entry point, and packages a Pages-compatible artifact.
+It does not configure or deploy a Pages site. Read the Docs owns publication;
+all code and conformance checks run locally.

--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,7 +1,7 @@
 # gorti v0.9.0 — HLA Evolved conformance release
 
 First public release with the complete IEEE 1516-2010 service surface and
-a CI-enforced conformance program. License: MIT.
+a locally enforced conformance program. License: MIT.
 
 ## Headlines
 
@@ -19,9 +19,9 @@ a CI-enforced conformance program. License: MIT.
   §-sections. The PRTI_HOME-gated harness allows anyone with a DLC-
   conformant RTI to independently reproduce the cross-check. Scoreboard +
   caveats: `docs/PITCH_PARITY.md`.
-- **Conformance CI** (`.github/workflows/conformance.yml` +
-  `scripts/ci-gates.sh`): stubs → go → cpp → lockfile → static → sweep →
-  ivct on every push/PR. Fixture verdicts are pinned in
+- **Local conformance gate** (`scripts/ci-gates.sh`): stubs → go → cpp →
+  lockfile → static → sweep → ivct before releases and significant
+  changes. Fixture verdicts are pinned in
   `EXPECTED_VERDICTS.txt` and enforced in both directions — regressions
   AND unrecorded improvements fail.
 - **IVCT-inspired Python conformance subset**: 35 tests, 0 xfail
@@ -64,7 +64,7 @@ a CI-enforced conformance program. License: MIT.
   (gossip-based, no Raft); treat multi-node as experimental.
 - **Scale**: the M5 perf baseline (see README) is in-process; large
   distributed federations are unbenchmarked.
-- Spec-derived goldens are cross-validated by CI against live gorti, but
+- Spec-derived goldens are cross-validated locally against live gorti, but
   large-scale cross-validation against other DLC-conformant RTIs (Portico,
   MAK, Pitch Pro) is future work. The three goldens within the free-edition
   federate cap were locally confirmed byte-for-byte identical to a reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,5 @@
 site_name: gorti
 site_description: Open-source IEEE 1516-2010 (HLA Evolved) RTI in Go
-site_url: https://cbchoi.github.io/gorti/
 repo_url: https://github.com/cbchoi/gorti
 repo_name: cbchoi/gorti
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Summary

Describe the problem and the chosen change.

## Semantics

- [ ] HLA service behavior is unchanged, or the intended change is documented.
- [ ] ACK, callback, time-order, and teardown boundaries were considered.

## Verification

- [ ] Go tests pass.
- [ ] Affected Python/C++ tests pass.
- [ ] Documentation builds with `mkdocs build --strict`.
- [ ] Performance claims follow `docs/reproducibility.md`.

## Documentation

List user-facing documentation and changelog updates.
